### PR TITLE
Use UTF-8 example from go blog

### DIFF
--- a/go-class/src/basics/basics.go
+++ b/go-class/src/basics/basics.go
@@ -9,9 +9,10 @@ func main() {
 	x = 3.0 + y
 	fmt.Println("x:", x, ", y:", y, ", z:", z)
 
-	const str string = "this is a 日本語 string\n"
-	var ch byte = str[12]
-	r := []rune(str)
-	fmt.Printf("ch: %q, rune: %q\n", ch, r[12])
-	fmt.Printf("ch  : %[1]q/%[1]v/%016[1]b\nrune: %[2]q/%[2]v/%016[2]b\n", ch, r[12])
+	const nihongo string = "日本語"
+
+	for index, runeValue := range nihongo {
+		fmt.Printf("%#U starts at byte position %d\n", runeValue, index)
+	}
+
 }


### PR DESCRIPTION
Use UTF-8 example from go blog.

The existing example demonstrates advanced formatting features. I tried to make it simpler for the non-experienced audience (copy it from the go blog). I know that the loops are introduced much later, but here we can focus on what's printed out and not on the loop syntax. Feel free to reject this PR if you think it's not worth it. 